### PR TITLE
remove warn_create_global opt

### DIFF
--- a/functions/history-search-multi-word
+++ b/functions/history-search-multi-word
@@ -29,7 +29,7 @@ integer path_dirs_was_set multi_func_def ointeractive_comments
 -hsmw-highlight-fill-option-variables
 
 builtin emulate -RL zsh ${=${options[xtrace]:#off}:+-o xtrace}
-builtin setopt extended_glob warn_create_global typeset_silent \
+builtin setopt extended_glob typeset_silent \
 local_traps prompt_subst no_short_loops rc_quotes no_auto_pushd
 
 # When an error, then no cursor keys bindings


### PR DESCRIPTION
if not remove, it will prompt when hit <kbd>Ctrl</kbd>+<kbd>R</kbd> :
```
_hsmw_main:19: scalar parameter __hsmw_hcw_finished created globally in function _hsmw_main
_hsmw_main:115: array parameter reply created globally in function _hsmw_main
```
and in context view <kbd>Ctrl</kbd>+<kbd>K</kbd> :
```
_hsmw_ctx_main:51: array parameter __hsmw_ctx_disp_list_newlines created globally in function _hsmw_ctx_main
_hsmw_ctx_main:55: scalar parameter MATCH created globally in function _hsmw_ctx_main
_hsmw_ctx_main:55: numeric parameter MBEGIN created globally in function _hsmw_ctx_main
_hsmw_ctx_main:55: numeric parameter MEND created globally in function _hsmw_ctx_main
```