### PR TITLE
Clean up, add links & alt text, improve formatting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,29 +1,37 @@
 <h1 align="center"><p>
-<a href="https://github.com/z-shell/zi" target="_blank">
-  <img src="https://github.com/z-shell/zi/raw/main/docs/images/logo.svg" alt="Logo" width="60px" height="60px" />
-</a>❮ Zi ❯ - History Search Multi Word</p>
-</h1>
+  <a href="https://github.com/z-shell/zi" target="_blank">
+    <img src="https://github.com/z-shell/zi/raw/main/docs/images/logo.svg" alt="ZI logo" width="60px" height="60px" />
+    ❮ ZI ❯
+  </a> - H-S-MW (History Search Multi Word)
+</p></h1>
 <h2 align="center"><p>
-Binds <kbd>Ctrl-R</kbd> to a widget that searches for multiple keywords in `AND` fashion.</p></h2>
-<h3 align="center"><p>
- In other words, you can enter multiple words, and history entries that match all of them will be found. The entries are syntax highlighted.</p></h3>
-<p align="center"><a href="https://asciinema.org/a/155704" target="_blank"><img src="https://asciinema.org/a/155704.svg" /></a></p>
+  Binds <kbd>Ctrl-R</kbd> to search for multiple keywords.<br/>
+  History entries that match all keywords will be found and syntax highlighted.
+</p></h2>
+</p></h3>
+<p align="center"><a href="https://asciinema.org/a/155704" target="_blank"><img src="https://asciinema.org/a/155704.svg" alt="ASCIInema Colored Zsh History – context of command demo" /></a></p>
 <p align="center"><a href="../LICENSE" target="_blank">
   <img align="center" src="https://img.shields.io/badge/license-GNU%20GPL%20version%203-blue.svg?style=flat-square" alt="License (GPL version 3)">
 </a>
-<img align="center" src="https://img.shields.io/badge/zsh-v5.0.0-orange.svg?style=flat-square" alt="ZSH 5.0.0"></p><hr />
+<img align="center" src="https://img.shields.io/badge/zsh-v5.0.0-orange.svg?style=flat-square" alt="ZSH v5.0.0"></p><hr />
 
 ## Customizing
 
-H-S-MW has feature called **context viewing** – see all occurrences of a command together with surrounding commands set:
+### Context viewing
 
-```shell
+See all occurrences of a command together with surrounding commands set:
+
+```zsh
 zstyle :plugin:history-search-multi-word reset-prompt-protect 1
 ```
 
-Use `zle reset-prompt` in `sched` calls, in presence of `z-shell/F-Sy-H`, `zsh-users/zsh-syntax-highlighting`, `zsh-users/zsh-autosuggestions` and other plugins that hook up into Zshell by overloading Zle widgets, e.g.:
+### reset-prompt
 
-```shell
+Use `zle reset-prompt` in `sched` calls, in the presence of [`z-shell/F-Sy-H`](https://github.com/z-shell/F-Sy-H), [`zsh-users/zsh-syntax-highlighting`](https://github.com/zsh-users/zsh-syntax-highlighting), [`zsh-users/zsh-autosuggestions`](https://github.com/zsh-users/zsh-autosuggestions), and other plugins that hook up into Z-Shell by overloading ZLE widgets.
+
+For example, to refresh the clock in prompt every second:
+
+```zsh
 PROMPT=%B%F{yellow}%D{%H:%M:%S}%B%b%f
 schedprompt() {
   zle && zle reset-prompt
@@ -34,11 +42,13 @@ zmodload -i zsh/sched
 schedprompt
 ```
 
-Refresh the clock in prompt every second. The `reset-prompt-protect` zstyle needs to be set to 1 for correct cooperation with H-S-MW. Or, you could use `zle .reset-prompt` (i.e. with the dot in front) to call the original, not overloaded (by F-Sy-H, zsh-autosuggestions, etc.) `reset-prompt` widget.
+The `reset-prompt-protect` zstyle needs to be set to 1 for correct cooperation with H-S-MW.
+
+Alternatively, you could use `zle .reset-prompt` (i.e. with the dot in front) to call the original, not an overloaded `reset-prompt` widget (created by [F-Sy-H](https://github.com/z-shell/F-Sy-H), [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions), etc.).
 
 ### Zstyles
 
-```shell
+```zsh
 zstyle ":history-search-multi-word" page-size "8"                      # Number of entries to show (default is $LINES/3)
 zstyle ":history-search-multi-word" highlight-color "fg=yellow,bold"   # Color in which to highlight matched, searched text (default bg=17 on 256-color terminals)
 zstyle ":plugin:history-search-multi-word" synhl "yes"                 # Whether to perform syntax highlighting (default true)
@@ -49,60 +59,62 @@ zstyle ":plugin:history-search-multi-word" clear-on-cancel "no"        # Whether
 
 ### Syntax highlighting
 
-Syntax highlighting is customized via `HSMW_HIGHLIGHT_STYLES` associative array. It has keys like `reserved-word`, `alias`, `command`, `path`, etc. which are assigned with strings like `fg=blue,bold`, to configure how given elements are to be colored.
+Syntax highlighting is customized via `HSMW_HIGHLIGHT_STYLES` associative array. It has keys like `reserved-word`, `alias`, `command`, `path`, etc. which are assigned with strings like `fg=blue,bold`, to configure how given elements are to be colored. The complete list of available keys is at the beginning of [`functions/hsmw-highlight`](/functions/hsmw-highlight#L36-L65).
 
-If you assign this array before or after loading `hsmw` you will change the defaults. Complete list of available keys is [at the beginning](https://github.com/z-shell/H-S-MW/blob/main/functions/hsmw-highlight#L34-L62) of `hsmw-highlight` file. Example `~/.zshrc` addition that sets `path` key – paths that exist will be highlighted with background magenta, foreground white, bold:
+If you assign this array in `~/.zshrc` before or after loading `hsmw` you will change the defaults.
 
-```shell
+#### Examples
+
+1. Sets `path` key – paths that exist will be highlighted with background magenta, foreground white, bold
+
+```zsh
 typeset -gA HSMW_HIGHLIGHT_STYLES
 HSMW_HIGHLIGHT_STYLES[path]="bg=magenta,fg=white,bold"
 ```
 
-Following code will enable coloring of options of form "-o" and "--option", with cyan:
+2. Enable coloring of options of form "-o" and "--option", with cyan
 
-```shell
+```zsh
 typeset -gA HSMW_HIGHLIGHT_STYLES
 HSMW_HIGHLIGHT_STYLES[single-hyphen-option]="fg=cyan"
 HSMW_HIGHLIGHT_STYLES[double-hyphen-option]="fg=cyan"
 ```
 
-Following code will use 256 colors to highlight command separators (like ";" or "&&"):
+3. Use 256 colors to highlight command separators (like ";" or "&&")
 
-```shell
+```zsh
 HSMW_HIGHLIGHT_STYLES[commandseparator]="fg=241,bg=17"
 ```
 
 ## Installation
 
-**The plugin is "standalone"**, which means that only sourcing it is needed. So to
-install, unpack `H-S-MW` somewhere and add to `zshrc`:
+**The plugin is "standalone"**, which means that only sourcing it is needed. So to install, unpack `H-S-MW` somewhere and add to `~/.zshrc`:
 
-```shell
+```zsh
 source {where-hsmw-is}/H-S-MW.plugin.zsh
 ```
 
-If using a plugin manager, then `Zi` is recommended, but you can use any other too, and also install with `Oh My Zsh` (by copying directory to `~/.oh-my-zsh/custom/plugins`).
+If using a plugin manager, then [ZI](https://github.com/z-shell/zi) is recommended, but you can use others if you prefer:
 
-### [Zi](https://github.com/z-shell/zi)
+### [ZI](https://github.com/z-shell/zi)
 
-Add `zi load z-shell/H-S-MW` to your `.zshrc` file. Zi will handle cloning the plugin for you automatically the next time you start zsh.
+Add `zi load z-shell/H-S-MW` to your `~/.zshrc` file. ZI will handle cloning the plugin for you automatically the next time you start zsh.
 
-### Zinit
-
-Add `zinit load z-shell/H-S-MW` to your `.zshrc` file.
-
-### Antigen
-
-Add `antigen bundle z-shell/H-S-MW` to your `.zshrc` file. Antigen will handle cloning the plugin for you automatically the next time you start zsh. You can also add the plugin to a running zsh with `antigen bundle z-shell/H-S-MW` for testing before adding it to your `.zshrc`.
-
-### Oh-My-Zsh
+### [Oh My Zsh](https://github.com/robbyrussell/oh-my-zsh) (OMZ)
 
 1. `cd ~/.oh-my-zsh/custom/plugins`
 2. `git clone git@github.com:z-shell/H-S-MW.git`
 3. Add `H-S-MW` to your plugin list
 
-### Zgen
+### [Zinit](https://github.com/zdharma-continuum/zinit)
 
-Add `zgen load z-shell/H-S-MW` to your .zshrc file in the same place you're doing your other `zgen load` calls in.
+Add `zinit load z-shell/H-S-MW` to your `.zshrc` file.
 
-1. Start a new terminal session
+### [Antigen](https://github.com/zsh-users/antigen)
+
+Add `antigen bundle z-shell/H-S-MW` to your `.zshrc` file. Antigen will handle cloning the plugin for you automatically the next time you start zsh. You can also add the plugin to a running zsh with `antigen bundle z-shell/H-S-MW` for testing before adding it to your `.zshrc`.
+
+### [Zgen](https://github.com/tarjoilija/zgen)
+
+1. Add `zgen load z-shell/H-S-MW` to your .zshrc file in the same place you're doing your other `zgen load` calls in.
+2. Start a new terminal session


### PR DESCRIPTION
1. Fixed link to /functions/hsmw-highlight#L36-L65 to use correct lines and relative link. I suggest trying https://github.com/tokusumi/markdown-embed-code to make this automatic, but doing so requires access to GitHub Actions, so I can't test it.
2. Cleaned up various text. Changed title to indicate both short and expanded name of H-S-MW, and to link ZI in the text (not just the logo).
3. Linked referenced projects
4. Changed code block info strings from `shell` to `zsh`
5. Changed "Zi" to "ZI", "Zle" to "ZLE", & "Zshell" to "Z-Shell" in non-code text (because these are the correct formatting and better for screen readers), and added or improved alt text
6. Added section & list format for examples
7. Made the zgen install use a list. 
  * However, I couldn't verify whether there should be anything after "start a new terminal session", other than to trace that it was modified in https://github.com/z-shell/H-S-MW/commit/de15f61ac60c00e7340729108978b71aa9130805 at https://github.com/z-shell/H-S-MW/commit/de15f61ac60c00e7340729108978b71aa9130805#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L105

Signed-off-by: Sai <github@saizai.com>